### PR TITLE
Pass a function to bindPopup

### DIFF
--- a/plugin/src/main/resources/web/modules/util/Markers.js
+++ b/plugin/src/main/resources/web/modules/util/Markers.js
@@ -9,7 +9,7 @@ class Marker {
     init() {
         if (this.tooltip != null) {
             // use popup instead of tooltip (tooltips are mouse over, popups are on click)
-            this.marker.bindPopup(this.tooltip);
+            this.marker.bindPopup(() => this.tooltip);
         }
         for (const key in this.opts) {
             this.marker.options[key] = this.opts[key];


### PR DESCRIPTION
Passing a function returning the content, instead of the content directly, to `bindPopup`. This will make leaflet create the popup when it is needed rather that immediately. If you have many popups to create this will be a significant performance improvement.