### PR TITLE
Use canvas renderer for rendering paths

### DIFF
--- a/plugin/src/main/resources/web/modules/Pl3xMap.js
+++ b/plugin/src/main/resources/web/modules/Pl3xMap.js
@@ -11,6 +11,7 @@ class Pl3xMap {
             crs: L.CRS.Simple,
             center: [0, 0],
             attributionControl: false,
+            preferCanvas: true,
             noWrap: true
         })
         .on('overlayadd', (e) => {


### PR DESCRIPTION
Leaflet by default renders paths as `<svg>` elements, which can cause performance issues when hundreds of them are added to the map, a real possibility with claim plugins.

[Setting `preferCanvas: true`](https://leafletjs.com/reference-1.7.1.html#map-prefercanvas) on the map will cause leaflet to render all paths to a `<canvas>` instead, which browsers handle much better at high path counts.

A sufficiently high number of paths is going to drag the browser down no matter what, but this change noticeably increases the limit of what can be added while maintaining acceptable performance.