### PR TITLE
Be able to start tracking player through url parameter

### DIFF
--- a/plugin/src/main/resources/web/js/modules/Pl3xMap.js
+++ b/plugin/src/main/resources/web/js/modules/Pl3xMap.js
@@ -126,8 +126,8 @@ class Pl3xMap {
         const zoom = this.map.getZoom();
         const x = Math.floor(center.x);
         const z = Math.floor(center.y);
-        const followedPlayer = this.playerList.getFollowedPlayer();
-        return `?world=${this.worldList.curWorld.name}&zoom=${zoom}&x=${x}&z=${z}${(followedPlayer ? `&uuid=${followedPlayer}` : '' )}`;
+        const following = this.playerList.following ? `&uuid=${this.playerList.following}` : '';
+        return `?world=${this.worldList.curWorld.name}&zoom=${zoom}&x=${x}&z=${z}${following}`;
     }
     updateBrowserUrl(url) {
         window.history.replaceState(null, "", url);

--- a/plugin/src/main/resources/web/js/modules/Pl3xMap.js
+++ b/plugin/src/main/resources/web/js/modules/Pl3xMap.js
@@ -126,7 +126,8 @@ class Pl3xMap {
         const zoom = this.map.getZoom();
         const x = Math.floor(center.x);
         const z = Math.floor(center.y);
-        return `?world=${this.worldList.curWorld.name}&zoom=${zoom}&x=${x}&z=${z}`;
+        const followedPlayer = this.playerList.getFollowedPlayer();
+        return `?world=${this.worldList.curWorld.name}&zoom=${zoom}&x=${x}&z=${z}${(followedPlayer ? `&uuid=${followedPlayer}` : '' )}`;
     }
     updateBrowserUrl(url) {
         window.history.replaceState(null, "", url);

--- a/plugin/src/main/resources/web/js/modules/PlayerList.js
+++ b/plugin/src/main/resources/web/js/modules/PlayerList.js
@@ -85,8 +85,9 @@ class PlayerList {
 	// First tick: Are we tracking someone by url parameter?
         if (this.firstTick) {
             this.firstTick = false;
-            if (P.getUrlParam("uuid", null) != null) {
-                this.followPlayerMarker(P.getUrlParam("uuid", null));
+            const trackedUuid = P.getUrlParam("uuid", null);
+            if (trackedUuid != null && this.players.get(trackedUuid) != null) {
+                this.followPlayerMarker(trackedUuid);
             }
         }
 

--- a/plugin/src/main/resources/web/js/modules/PlayerList.js
+++ b/plugin/src/main/resources/web/js/modules/PlayerList.js
@@ -119,6 +119,10 @@ class PlayerList {
             document.getElementById(this.following).classList.add("following");
         }
     }
+
+    getFollowedPlayer() {
+        return this.following;
+    }
 }
 
 export { PlayerList };

--- a/plugin/src/main/resources/web/js/modules/PlayerList.js
+++ b/plugin/src/main/resources/web/js/modules/PlayerList.js
@@ -82,12 +82,14 @@ class PlayerList {
             this.removeFromList(player);
         }
 
-	// First tick: Are we tracking someone by url parameter?
+        // first tick only
         if (this.firstTick) {
             this.firstTick = false;
-            const trackedUuid = P.getUrlParam("uuid", null);
-            if (trackedUuid != null && this.players.get(trackedUuid) != null) {
-                this.followPlayerMarker(trackedUuid);
+
+            // follow uuid from url
+            const follow = P.getUrlParam("uuid", null);
+            if (follow != null && this.players.get(follow) != null) {
+                this.followPlayerMarker(follow);
             }
         }
 
@@ -119,10 +121,6 @@ class PlayerList {
             this.following = uuid;
             document.getElementById(this.following).classList.add("following");
         }
-    }
-
-    getFollowedPlayer() {
-        return this.following;
     }
 }
 

--- a/plugin/src/main/resources/web/js/modules/PlayerList.js
+++ b/plugin/src/main/resources/web/js/modules/PlayerList.js
@@ -6,6 +6,7 @@ class PlayerList {
         this.players = new Map();
         this.markers = new Map();
         this.following = null;
+        this.firstTick = true;
         this.label = json.player_list_label;
         P.map.createPane("nameplate").style.zIndex = 1000;
     }
@@ -79,6 +80,14 @@ class PlayerList {
         for (let i = 0; i < playersToRemove.length; i++) {
             const player = this.players.get(playersToRemove[i]);
             this.removeFromList(player);
+        }
+
+	// First tick: Are we tracking someone by url parameter?
+        if (this.firstTick) {
+            this.firstTick = false;
+            if (P.getUrlParam("uuid", null) != null) {
+                this.followPlayerMarker(P.getUrlParam("uuid", null));
+            }
         }
 
         // follow highlighted player


### PR DESCRIPTION
I'm normally not a frontend guy, so I'm not sure if this is the best approach. 

This functionally adds an uuid query parameter so you can start following a player by directly opening a link. This enables the application to be used in twitch overlays where it automatically starts following specific people when they are online. 

This was a specific usecase from my server which has several streamers in it, I thought this could be useful aswell for others.