### PR TITLE
Prevent queue backups by blocking for job completion

### DIFF
--- a/plugin/src/main/java/net/pl3x/map/plugin/task/render/BackgroundRender.java
+++ b/plugin/src/main/java/net/pl3x/map/plugin/task/render/BackgroundRender.java
@@ -53,7 +53,7 @@ public final class BackgroundRender extends AbstractRender {
         });
         if (!futures.isEmpty()) {
             CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
-            Logger.info(String.format("Finished background render cycle in %.2f seconds",
+            Logger.debug(String.format("Finished background render cycle in %.2f seconds",
                     (double) (System.currentTimeMillis() - time) / 1000.0D));
         }
     }

--- a/plugin/src/main/java/net/pl3x/map/plugin/task/render/BackgroundRender.java
+++ b/plugin/src/main/java/net/pl3x/map/plugin/task/render/BackgroundRender.java
@@ -1,5 +1,7 @@
 package net.pl3x.map.plugin.task.render;
 
+import java.util.ArrayList;
+import net.pl3x.map.plugin.Logger;
 import net.pl3x.map.plugin.data.ChunkCoordinate;
 import net.pl3x.map.plugin.data.Image;
 import net.pl3x.map.plugin.data.MapWorld;
@@ -32,13 +34,14 @@ public final class BackgroundRender extends AbstractRender {
 
     @Override
     protected void render() {
-
+        long time = System.currentTimeMillis();
         final Set<ChunkCoordinate> chunks = new HashSet<>();
         while (mapWorld.hasModifiedChunks() && chunks.size() < mapWorld.config().BACKGROUND_RENDER_MAX_CHUNKS_PER_INTERVAL) {
             chunks.add(mapWorld.nextModifiedChunk());
         }
         final Map<Region, List<ChunkCoordinate>> coordMap = chunks.stream().collect(Collectors.groupingBy(ChunkCoordinate::regionCoordinate));
 
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
         coordMap.forEach((region, chunkCoords) -> {
             final Image img = new Image(region, worldTilesDir, mapWorld.config().ZOOM_MAX);
 
@@ -46,7 +49,12 @@ public final class BackgroundRender extends AbstractRender {
                     mapSingleChunk(img, coord.getX(), coord.getZ())).toArray(CompletableFuture[]::new));
 
             future.whenComplete((result, throwable) -> mapWorld.saveImage(img));
+            futures.add(future);
         });
-
+        if (!futures.isEmpty()) {
+            CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
+            Logger.info(String.format("Finished background render cycle in %.2f seconds",
+                    (double) (System.currentTimeMillis() - time) / 1000.0D));
+        }
     }
 }


### PR DESCRIPTION
At high player counts with many chunk operations being queued, especially with a high CPU load, the executor responsible for rendering tiles can become backed up. This patch prevents this issue by ensuring that no new jobs may be submitted to this executor by the background renderer before any previous jobs complete.

This issue manifests itself so badly because of the Image object pre-allocation in the background renderer. If jobs aren't completed fast enough, then these large Image objects simply sit around unused, taking up a significant amount of memory, eventually leading to crashes. This patch prevents this issue by blocking any new job submissions until previous jobs have completed.