### PR TITLE
Improve caching behaviour

### DIFF
--- a/plugin/src/main/resources/web/index.html
+++ b/plugin/src/main/resources/web/index.html
@@ -32,6 +32,7 @@
       crossOrigin="anonymous"></script>
     <script src="js/addons/RotateMarker.js" crossOrigin="anonymous"></script>
     <script src="js/addons/Ellipse.js" crossOrigin="anonymous"></script>
+    <script type="module" src="js/modules/Pl3xmapTileLayer.js" crossOrigin="anonymous"></script>
     <script type="module" src="js/modules/PlayerList.js" crossOrigin="anonymous"></script>
     <script type="module" src="js/modules/Sidebar.js" crossOrigin="anonymous"></script>
     <script type="module" src="js/modules/UICoordinates.js" crossOrigin="anonymous"></script>

--- a/plugin/src/main/resources/web/js/modules/LayerControl.js
+++ b/plugin/src/main/resources/web/js/modules/LayerControl.js
@@ -1,4 +1,5 @@
 import { P } from './Pl3xMap.js';
+import { Pl3xmapTileLayer } from './Pl3xmapTileLayer.js';
 
 class LayerControl {
     constructor() {
@@ -69,13 +70,10 @@ class LayerControl {
         this.playersLayer.setZIndex(world.player_tracker.z_index);
     }
     createTileLayer(world) {
-        return L.tileLayer(`tiles/${world.name}/{z}/{x}_{y}.png?{rand}`, {
+        return new Pl3xmapTileLayer(`tiles/${world.name}/{z}/{x}_{y}.png`, {
             tileSize: 512,
             minNativeZoom: 0,
-            maxNativeZoom: world.zoom.max,
-            rand: () => {
-                return Math.random();
-            }
+            maxNativeZoom: world.zoom.max
         }).addTo(P.map)
         .addEventListener("load", () => {
             // when all tiles are loaded, switch to this layer

--- a/plugin/src/main/resources/web/js/modules/Pl3xmapTileLayer.js
+++ b/plugin/src/main/resources/web/js/modules/Pl3xmapTileLayer.js
@@ -1,0 +1,42 @@
+export var Pl3xmapTileLayer = L.TileLayer.extend({
+
+    // @method createTile(coords: Object, done?: Function): HTMLElement
+    // Called only internally, overrides GridLayer's [`createTile()`](#gridlayer-createtile)
+    // to return an `<img>` HTML element with the appropriate image URL given `coords`. The `done`
+    // callback is called when the tile has been loaded.
+    createTile: function (coords, done) {
+        var tile = document.createElement('img');
+
+        L.DomEvent.on(tile, 'load', () => {
+            //Once image has loaded revoke the object URL as we don't need it anymore
+            URL.revokeObjectURL(tile.src);
+            this._tileOnLoad(done, tile)
+        });
+        L.DomEvent.on(tile, 'error', L.Util.bind(this._tileOnError, this, done, tile));
+
+        if (this.options.crossOrigin || this.options.crossOrigin === '') {
+            tile.crossOrigin = this.options.crossOrigin === true ? '' : this.options.crossOrigin;
+        }
+
+        tile.alt = '';
+        tile.setAttribute('role', 'presentation');
+
+        //Retrieve image via a fetch instead of just setting the src
+        //This works around the fact that browsers usually don't make a request for an image that was previously loaded,
+        //without resorting to changing the URL (which would break caching).
+        fetch(this.getTileUrl(coords))
+            .then(res => {
+                //Call leaflet's error handler if request fails for some reason
+                if (!res.ok) {
+                    this._tileOnError(this, done, tile);
+                    return;
+                }
+
+                //Get image data and convert into object URL so it can be used as a src
+                //Leaflet's onload listener will take it from here
+                res.blob().then(blob => tile.src = URL.createObjectURL(blob));
+            }).catch(() => this._tileOnError(this, done, tile));
+
+        return tile;
+    }
+});


### PR DESCRIPTION
This PR attempts to improve Pl3xmap's leverage of browser caching. Currently Pl3xmap adds cache-busting query strings to all tile URLs, which ensures the tiles are up to date but also prevents browsers from caching the images effectively. This combined with the regular redrawing of the map's `TileLayer` causes excessive bandwidth usage via repeated downloads of the same image.

This PR addresses this problem in 3 ways:

1. **Adding cache headers to the integrated server response**
   Tiles requested from the integrated server will now have a `Cache-Control: max-age=0, must-revalidate, no-cache` header applied. `must-revalidate/no-cache` will instruct the browser to ask the server about new versions of the image on subsequent loads, while `max-age=0` will ensure this happens immediately by making the image stale straight away.

   When combined with the existing `Last-modified` and `Etag` headers, browsers will now send `If-modified-since` and `If-none-match` headers on subsequent requests for the same tile URL, allowing the server to respond with a `304 Not Modified` if the tile hasn't changed, allowing the browser to use its existing copy without having to download it again. 
2. **Avoiding cache-busting query strings on tile URLs**
  The approach in point 1 will only work if the tile URLs remains the same, which requires the existing random numbers appended to tile URLs to be removed. On its own this prevents tiles from updating when the `TileLayer`  is redrawn, as there is no longer a URL change to cause it to do so.
3. **Use the fetch API for retrieving tiles**
  The stock `TileLayer` has been extended to use the Fetch API for retrieving tile image data, instead of relying on the browser to do so via setting an `<img>` src. This resolves the problem introduced in point 2 as we no longer depend on the browser deciding to re-request images, and fetch will by default respect cache headers and return a cached response where appropriate.

### Results
The result is significantly reduced bandwidth usage, whilst retaining the ability for tiles to update when they have changed. 

Build 155 after 1 minute idle
![image](https://user-images.githubusercontent.com/4615316/127783311-b027d993-34bc-4c07-a58d-d94ab057278d.png)

PR after 1 minute idle
![image](https://user-images.githubusercontent.com/4615316/127783437-9981fa22-3717-4554-b906-3b37a2825496.png)
The additional requests are due to object URLs showing up separately

### Caveats
There are some downsides to this approach:

1. Tile creation is significantly slower with fetch than with plain images, taking twice as long in my testing.
2. External web servers need to be configured appropriately to avoid tiles being cached for too long.

The first issue is noticeable during performance testing, but may not be for the average user. If it does become a problem however the fetch could be moved to a web worker, which brings performance back to the previous level. I considered that out of scope for this PR though.

The second issue can be solved by documenting an appropriate external server configuration, which would be to ensure tile images have  `Cache-Control: max-age=0, must-revalidate, no-cache`/`Last-modified`/`Etag` headers.