### PR TITLE
add others permission to hide and show command

### DIFF
--- a/plugin/src/main/java/net/pl3x/map/plugin/command/commands/HideCommand.java
+++ b/plugin/src/main/java/net/pl3x/map/plugin/command/commands/HideCommand.java
@@ -24,9 +24,14 @@ public final class HideCommand extends Pl3xMapCommand {
     public void register() {
         this.commandManager.registerSubcommand(builder ->
                 builder.literal("hide")
-                        .argument(SinglePlayerSelectorArgument.optional("player"), CommandUtil.description(Lang.OPTIONAL_PLAYER_ARGUMENT_DESCRIPTION))
                         .meta(MinecraftExtrasMetaKeys.DESCRIPTION, MiniMessage.get().parse(Lang.HIDE_COMMAND_DESCRIPTION))
                         .permission("pl3xmap.command.hide")
+                        .handler(this::executeHide));
+        this.commandManager.registerSubcommand(builder ->
+                builder.literal("hide")
+                        .argument(SinglePlayerSelectorArgument.optional("player"), CommandUtil.description(Lang.OPTIONAL_PLAYER_ARGUMENT_DESCRIPTION))
+                        .meta(MinecraftExtrasMetaKeys.DESCRIPTION, MiniMessage.get().parse(Lang.HIDE_COMMAND_DESCRIPTION))
+                        .permission("pl3xmap.command.hide.others")
                         .handler(this::executeHide));
     }
 

--- a/plugin/src/main/java/net/pl3x/map/plugin/command/commands/ShowCommand.java
+++ b/plugin/src/main/java/net/pl3x/map/plugin/command/commands/ShowCommand.java
@@ -24,9 +24,14 @@ public final class ShowCommand extends Pl3xMapCommand {
     public void register() {
         this.commandManager.registerSubcommand(builder ->
                 builder.literal("show")
-                        .argument(SinglePlayerSelectorArgument.optional("player"), CommandUtil.description(Lang.OPTIONAL_PLAYER_ARGUMENT_DESCRIPTION))
                         .meta(MinecraftExtrasMetaKeys.DESCRIPTION, MiniMessage.get().parse(Lang.SHOW_COMMAND_DESCRIPTION))
                         .permission("pl3xmap.command.show")
+                        .handler(this::executeShow));
+        this.commandManager.registerSubcommand(builder ->
+                builder.literal("show")
+                        .argument(SinglePlayerSelectorArgument.optional("player"), CommandUtil.description(Lang.OPTIONAL_PLAYER_ARGUMENT_DESCRIPTION))
+                        .meta(MinecraftExtrasMetaKeys.DESCRIPTION, MiniMessage.get().parse(Lang.SHOW_COMMAND_DESCRIPTION))
+                        .permission("pl3xmap.command.show.others")
                         .handler(this::executeShow));
     }
 


### PR DESCRIPTION
This PR closes #21 by separating the playerselector argument into it's own permission for both the show and hide commands.

Not sure if this is the "correct" way of registering the permission, but I've tested it and it works.