### PR TITLE
throw away while loop in block & biome registry

### DIFF
--- a/core/src/main/java/net/pl3x/map/core/registry/BiomeRegistry.java
+++ b/core/src/main/java/net/pl3x/map/core/registry/BiomeRegistry.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class BiomeRegistry extends Registry<@NotNull Biome> {
     private static final Gson GSON = new GsonBuilder().create();
+    private static final int MAX_INDEX = 1023;
 
     private final Map<String, Integer> indexMap;
 
@@ -67,21 +68,23 @@ public class BiomeRegistry extends Registry<@NotNull Biome> {
         if (index > -1) {
             return index;
         }
-        int i = 0;
-        while (true) {
-            if (!this.indexMap.containsValue(i)) {
-                this.indexMap.put(id, i);
-                return i;
-            }
-            i++;
-        }
+
+        int i = this.indexMap.size();
+        if (i > MAX_INDEX) return -1;
+
+        this.indexMap.put(id, i);
+        return i;
     }
 
-    public @NotNull Biome register(@NotNull String id, int color, int foliage, int grass, int water, Biome.@NotNull GrassModifier grassModifier) {
+    public Biome register(@NotNull String id, int color, int foliage, int grass, int water, Biome.@NotNull GrassModifier grassModifier) {
         if (has(id)) {
             throw new KeyAlreadyExistsException("Biome already registered: " + id);
         }
-        return register(id, new Biome(getNextIndex(id), id, color, foliage, grass, water, grassModifier));
+
+        int nextIndex = getNextIndex(id);
+        if (nextIndex == -1) return null;
+
+        return register(id, new Biome(nextIndex, id, color, foliage, grass, water, grassModifier));
     }
 
     @Override

--- a/core/src/main/java/net/pl3x/map/core/world/Blocks.java
+++ b/core/src/main/java/net/pl3x/map/core/world/Blocks.java
@@ -1042,6 +1042,9 @@ public class Blocks {
     }
 
     public static void registerDefaults() {
-        blocks.forEach((id, block) -> Pl3xMap.api().getBlockRegistry().register(id, block));
+        blocks.forEach((id, block) -> {
+            Pl3xMap.api().getBlockRegistry().register(id, block);
+            Pl3xMap.api().getBlockRegistry().getIndexMap().put(id, block.getIndex());
+        });
     }
 }


### PR DESCRIPTION
This greatly increases performance when registering an extremely large amount of blocks and biomes. Since this is the only place where we add to the indexMap, it's safe to increment it based on it's size. This change decreases the time for registering 9066 blocks from 20 minutes down to ~5 seconds.